### PR TITLE
[26주차 / 박정근] 문제 풀이 

### DIFF
--- a/박정근/BOJ/Week26/[22862]가장_긴_짝수_연속한_부분_수열_(large).java
+++ b/박정근/BOJ/Week26/[22862]가장_긴_짝수_연속한_부분_수열_(large).java
@@ -1,6 +1,6 @@
 /**
  * Author    : Park Jeong Geun
- * Date      : 2024.11.25(Mon)
+ * Date      : 2024.11.30(Sat)
  * Runtime   : 516ms
  * Memory    : 118692KB
  * Algorithm : Two Pointer
@@ -31,10 +31,10 @@ class Main {
         st = new StringTokenizer(br.readLine());
         for (int i = 0; i < n; i++) arr[i] = Integer.parseInt(st.nextToken());
 
+        // 1) 짝수 부분 개수 / 홀수 부분 개수 / 짝 / 홀 ... 배열 만들기
         int[][] cnt_arr = new int[n][2];
         for (int i = 0; i < n; i++) Arrays.fill(cnt_arr[i], 0);
 
-        // 1) 짝수 부분 개수 / 홀수 부분 개수 / 짝 / 홀 ... 배열 만들기
         int mode = 0; // 0 : 짝수 부분 / 1 : 홀수 부분
         int idx = 0;
         int cnt = 1;

--- a/박정근/BOJ/Week26/[22862]가장_긴_짝수_연속한_부분_수열_(large).java
+++ b/박정근/BOJ/Week26/[22862]가장_긴_짝수_연속한_부분_수열_(large).java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 
 class Main {
 	static public void main(String []args) throws IOException {
+		// +@ 깃허브가 여기 indent를 자꾸 씹습니다.. 응애...
 		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
         StringTokenizer st = new StringTokenizer(br.readLine());
 

--- a/박정근/BOJ/Week26/[22862]가장_긴_짝수_연속한_부분_수열_(large).java
+++ b/박정근/BOJ/Week26/[22862]가장_긴_짝수_연속한_부분_수열_(large).java
@@ -1,0 +1,95 @@
+/**
+ * Author    : Park Jeong Geun
+ * Date      : 2024.11.25(Mon)
+ * Runtime   : 516ms
+ * Memory    : 118692KB
+ * Algorithm : Two Pointer
+ */
+
+// >> 첫 번째 풀이 ( 투 포인터 )
+// 주 아이디어 : 짝수들을 건너뛰고, 연속된 홀수 수열들을 지울 때 홀수를 최대 K개만큼 제거하면, 제거한 홀수 부분과 이웃하는 연속한 짝수 부분들을 서로 이어서 길게 만들 수 있습니다.
+// 먼저, 주어진 수열을 짝수 부분 개수 / 홀수 부분 개수 / 짝 ... 짝 / 홀 / 짝 으로 가공해서, 홀수 부분을 지웠을 때 양옆에 있는 짝수 부분을 파악할 수 있도록 처리했습니다.
+// -> 맨 처음과 맨 마지막에 홀수 부분이 있다면 생략으로 처리해도 됩니다. (그 부분은 지우면 비효율적입니다. 각각 맨 끝에서 두 번째 홀수 부분을 지우면 얻을 수 있기 때문입니다.)
+// 현재 수열에서 아무것도 지우지 않았을 때, 짝수 부분 중 최대 길이 부분을 구했습니다. (홀수 부분들이 전부 K개보다 많은 홀수를 가지고 있을 수 있습니다.)
+// 그리고, 투 포인터를 사용해 홀수를 최대 K번 지웠을 때 얻을 수 있는 최대 길이 짝수 수열을 구했습니다.
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+import java.util.Arrays;
+
+class Main {
+	static public void main(String []args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int n = Integer.parseInt(st.nextToken());
+        int k = Integer.parseInt(st.nextToken());
+
+        int[] arr = new int[n];
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < n; i++) arr[i] = Integer.parseInt(st.nextToken());
+
+        int[][] cnt_arr = new int[n][2];
+        for (int i = 0; i < n; i++) Arrays.fill(cnt_arr[i], 0);
+
+        // 1) 짝수 부분 개수 / 홀수 부분 개수 / 짝 / 홀 ... 배열 만들기
+        int mode = 0; // 0 : 짝수 부분 / 1 : 홀수 부분
+        int idx = 0;
+        int cnt = 1;
+        for (int i = 0; i < n; i++) {
+            if (i == 0) mode = arr[i] % 2;
+            else {
+                if (mode != (arr[i] % 2)) { // 짝수 -> 홀수 / 홀수 -> 짝수로 바뀔 때
+                    if ((mode == 0) || (cnt_arr[idx][0] != 0)) { // 제일 처음 등장하는 홀수 부분을 빼는 조건입니다. 처음 부분에는 짝수 부분을 먼저 넣고 홀수 부분을 넣을 수 있도록 해줍니다.
+                        cnt_arr[idx][mode] = cnt;
+                        if (mode == 1) idx += 1; // 홀수 부분을 넣었다면 다음 인덱스로 넘어갑니다.
+                    }
+
+                    cnt = 1;
+                    mode ^= 1;
+                }
+                else cnt += 1;
+            }
+        }
+        cnt_arr[idx][mode] = cnt; 
+
+        // 2) 아무것도 지우지 않았을 때, 짝수 부분들 중 최대 길이 구하기
+        int res = 0;
+        for (int i = 0; i <= idx; i++) res = Math.max(res, cnt_arr[i][0]); // 현재 짝수 부분들 중 최대 길이를 구해놓습니다.
+
+        // 3) 투 포인터로, 홀수를 최대 K번 지웠을 때 얻을 수 있는 최대 길이 짝수 수열 구하기
+        if (n >= 2) { // n이 1 이하면 64행에서 오류가 나기도 하고, 59행에서 이미 정답을 구했을 것이기에 조건을 달아줍니다.
+            int start = 0;
+            int end = 0;
+            int now = cnt_arr[0][0] + cnt_arr[1][0]; // 현재 얻은 짝수 부분 개수. (0번째 홀수 부분을 제거했다면, 0번째 짝수 부분과 1번째 짝수 부분을 얻을 수 있습니다.)
+            int need = cnt_arr[0][1]; // 현재 지워야 하는 홀수 개수 (0번째 홀수 부분에서의 홀수 개수만큼 지우는 것이 필요합니다.)
+
+            while (true) {
+                if (need > k) { // 만약 현재 k개보다 많이 지워야 한다면.. 앞에 있는 홀수 부분 하나를 지우지 않습니다. (당깁니다.)
+                    now -= cnt_arr[start][0]; // start번째 홀수 부분을 지우지 않는다면, start번째 짝수 부분은 얻을 수 없습니다. [start+1..]번째 짝수 부분만 남습니다.
+                    need -= cnt_arr[start][1]; // start번째 홀수 부분에서의 홀수 개수만큼은 지우지 않아도 됩니다.
+                    start += 1; 
+                    
+                    if (start > end) { // 만약 원래 홀수 부분 하나만 지우는 거였는데 start를 당겼다면, 뒤에 있는 홀수 부분 하나를 더 지웁니다. (밉니다.)
+                        end += 1;
+                        if (end > idx) break;
+                        now += cnt_arr[end+1][0]; // end번째 홀수 부분을 지운다면, [..end]번째 짝수 부분과 end+1번째 짝수 부분을 얻을 수 있습니다.
+                        need += cnt_arr[end][1]; // end번째 홀수 부분에서의 홀수 개수만큼 지우는 것이 필요합니다.
+                    }
+                }
+                else {
+                    res = Math.max(res, now); // 최대 k만큼 지울 수 있으므로, 현재 정답과 now 중 최댓값을 정답으로 대입합니다.
+                    
+                    end += 1; // 더 지워도 될 것 같으니, 뒤에 있는 홀수 부분 하나를 더 지웁니다. (밉니다.)
+                    if (end > idx) break;
+                    now += cnt_arr[end+1][0];
+                    need += cnt_arr[end][1];
+                }
+            }
+        }
+
+        System.out.println(res);
+    }
+}

--- a/박정근/Programmers/Week26/기능개발.java
+++ b/박정근/Programmers/Week26/기능개발.java
@@ -1,0 +1,46 @@
+/**
+ * Author    : Park Jeong Geun
+ * Date      : 2024.11.25(Mon)
+ * Runtime   : 0.04ms
+ * Memory    : 78.5MB
+ * Algorithm : Math
+ */
+
+// >> 첫 번째 풀이 ( 수학 )
+// (100 - 현재 작업 진도) / (작업 속도) + (나누어 떨어지지 않는다면 1) 식을 통해 작업마다 배포 날짜를 구했습니다.
+// 배포는 첫 번째 작업부터 순차적으로 이루어져야 하므로, 이전 작업이 늦게 끝난다면 다음 작업은 동시에 배포할 수 있고, 이전 작업이 빨리 끝난다면 다음 작업은 다음 배포 때 배포합니다.
+
+class Solution {
+    public int[] solution(int[] progresses, int[] speeds) {
+        int n = progresses.length;
+        int[] done_day = new int[n];
+
+        // 배포 날짜 : (100 - 현재 작업 진도) / (작업 속도) + (나누어 떨어지지 않는다면 1)
+        for (int i = 0; i < n; i++) {
+            done_day[i] = ((100 - progresses[i]) / speeds[i]) + (((100 - progresses[i]) % speeds[i]) == 0 ? 0 : 1);
+        }
+        
+        int[] res_arr = new int[n]; // 정답 배열은 길이가 가변적이므로, 스택 원리로 만들어냅니다.
+        int res_arr_idx = 0;
+        
+        int now_task = 1; // 현재 동시에 배포할 수 있는 작업의 수
+        int pre_task = done_day[0]; // 가장 늦게 끝난 이전 작업
+        for (int i = 1; i < n; i++) {
+            if (pre_task < done_day[i]) { // 이전 작업보다 늦게 끝난다면..
+                res_arr[res_arr_idx++] = now_task; // 이전 작업들을 배포한다.
+                
+                pre_task = done_day[i]; // 새로운 배포 : i번째 작업
+                now_task = 1; // 동시 배포 작업 수를 1로 초기화
+            }
+            else { // 이전 작업보다 빨리 끝난다면..
+                now_task += 1; // 동시에 배포할 수 있다.
+            }
+        }
+        res_arr[res_arr_idx++] = now_task; // 남은 작업 배포
+        
+        int[] answer = new int[res_arr_idx]; // 정답 배열
+        for (int i = 0; i < res_arr_idx; i++) answer[i] = res_arr[i];
+        
+        return answer;
+    }
+}

--- a/박정근/Programmers/Week26/순위_검색.java
+++ b/박정근/Programmers/Week26/순위_검색.java
@@ -1,8 +1,8 @@
 /**
  * Author    : Park Jeong Geun
  * Date      : 2024.11.18(Mon)
- * Runtime   : 287.20 ms
- * Memory    : 183MB
+ * Runtime   : 293.85 ms
+ * Memory    : 170MB
  * Algorithm : Prefix Sum + Brute force
  */
 
@@ -18,7 +18,7 @@ class Solution {
 
         // 누적 합 배열 info_sum
         // info_sum[i][j][k][l][p] : 개발언어가 i고, 직군이 j고, 경력이 k고, 소울푸드가 l이고 점수가 p 이상인 사람의 수
-        int[][][][][] info_sum = new int[3][3][3][3][100001];
+        int[][][][][] info_sum = new int[3][2][2][2][100001];
         
         for (String s : info) {
             StringTokenizer st = new StringTokenizer(s);
@@ -112,7 +112,6 @@ class Solution {
                     }      
                 }
             }
-            
             
             answer[q_idx++] = res;
         }

--- a/박정근/Programmers/Week26/순위_검색.java
+++ b/박정근/Programmers/Week26/순위_검색.java
@@ -1,0 +1,121 @@
+/**
+ * Author    : Park Jeong Geun
+ * Date      : 2024.11.18(Mon)
+ * Runtime   : 287.20 ms
+ * Memory    : 183MB
+ * Algorithm : Prefix Sum + Brute force
+ */
+
+// >> 첫 번째 풀이 ( 누적 합 + 완전 탐색 )
+// 4가지 항목마다 점수를 기준으로 누적 합을 만들었습니다. (5차원 배열 누적합)
+// 3 x 2 x 2 x 2 x 100000 만큼의 공간을 만들어야 하지만, 시간 안에는 해결할 수 있습니다.
+// 공간 복잡도를 이만큼 잡아먹는건 아닌 것 같아서 다른 방법을 떠올려 보려 했는데, 이게 저한테는 가장 원활한 방법으로 보이네요..
+
+import java.util.StringTokenizer;
+class Solution {
+    public int[] solution(String[] info, String[] query) {
+        int[] answer = new int[query.length];
+
+        // 누적 합 배열 info_sum
+        // info_sum[i][j][k][l][p] : 개발언어가 i고, 직군이 j고, 경력이 k고, 소울푸드가 l이고 점수가 p 이상인 사람의 수
+        int[][][][][] info_sum = new int[3][3][3][3][100001];
+        
+        for (String s : info) {
+            StringTokenizer st = new StringTokenizer(s);
+            
+            int[] idx = new int[4];
+            for (int c = 0; c < 4; c++) {
+                String now = st.nextToken();    
+                
+                switch(now) {
+                    case "cpp":
+                    case "backend":
+                    case "junior":
+                    case "chicken":
+                        idx[c] = 0;
+                        break;
+                    case "java":
+                    case "frontend":
+                    case "senior":
+                    case "pizza":
+                        idx[c] = 1;
+                        break;
+                    case "python":
+                        idx[c] = 2;
+                        break;
+                }
+            }
+            
+            info_sum[idx[0]][idx[1]][idx[2]][idx[3]][Integer.parseInt(st.nextToken())] += 1;
+        }
+        
+        // 누적 합 만들기 (특정 항목에서 X점 이상인 사람의 수)
+        for (int i = 0; i < 3; i++) {
+            for (int j = 0; j < 2; j++) {
+                for (int k = 0; k < 2; k++) {
+                    for (int l = 0; l < 2; l++) {
+                        for (int sc = 99999; sc >= 0; sc--) {
+                            info_sum[i][j][k][l][sc] += info_sum[i][j][k][l][sc+1];
+                        }
+                    }
+                }
+            }
+        }
+        
+        int q_idx = 0;
+        for (String q : query) {
+            StringTokenizer st = new StringTokenizer(q);
+            
+            int[] idx_start = new int[4];
+            int[] idx_end = {3, 2, 2, 2};
+            for (int c = 0; c < 4; c++) { 
+                String now;
+                if (c != 0) now = st.nextToken(); // 중간에 있는 and 빼기
+                now = st.nextToken();
+                
+                switch(now) {
+                    case "cpp":
+                    case "backend":
+                    case "junior":
+                    case "chicken":
+                        idx_start[c] = 0;
+                        idx_end[c] = 1;
+                        break;
+                    case "java":
+                    case "frontend":
+                    case "senior":
+                    case "pizza":
+                        idx_start[c] = 1;
+                        idx_end[c] = 2;
+                        break;
+                    case "python":
+                        idx_start[c] = 2;
+                        idx_end[c] = 3;
+                        break;
+                    case "-":
+                        idx_start[c] = 0;
+                        break;
+                }
+            }
+        
+            int sc = Integer.parseInt(st.nextToken()); // 점수 조건
+            int res = 0;
+            
+            // -1 이면 전체를 탐색할 수 있도록 했습니다. 
+            // 복잡해 보이지만, 한 쿼리마다 최대 3 x 2 x 2 x 2번의 순회로 답을 얻을 수 있습니다.
+            for (int i = idx_start[0]; i < idx_end[0]; i++) {
+                for (int j = idx_start[1]; j < idx_end[1]; j++) {
+                    for (int k = idx_start[2]; k < idx_end[2]; k++) {
+                        for (int l = idx_start[3]; l < idx_end[3]; l++) {
+                            res += info_sum[i][j][k][l][sc];
+                        }
+                    }      
+                }
+            }
+            
+            
+            answer[q_idx++] = res;
+        }
+        return answer;
+    }
+}


### PR DESCRIPTION
## :sparkles: Week26 박정근 문제풀이

- [X] <b>순위 검색</b>
> 누적 합 + 완전 탐색으로 풀이했습니다.

> 각각 항목, 점수에 해당하는 사람이 몇 명 있는지를 저장하고, 누적 합으로 특정 항목의 X점 이상 사람의 수를 바로 구할 수 있도록 구현했습니다. (5차원 배열 누적 합)
> 3 x 2 x 2 x 2 x 100000 만큼의 공간을 만들어야 하지만, 시간 안에는 해결할 수 있다고 생각해서 제출하고 정답을 받았습니다.
> 공간 복잡도를 이만큼 잡아먹는건 아닌 것 같아서 다른 방법을 떠올려 보려 했는데, 이게 저한테는 가장 원활한 방법으로 보이네요.. 다른 분들의 풀이가 궁금한 문제입니다. :eyes:

- [X] <b>기능개발</b>
> 수학으로 풀이했습니다.

> `(100 - 현재 작업 진도) / (작업 속도) + (나누어 떨어지지 않는다면 1)` 식을 통해 작업마다 배포 날짜를 구했습니다.
> 배포는 첫 번째 작업부터 순차적으로 이루어져야 하므로, 이전 작업이 늦게 끝난다면 다음 작업은 동시에 배포할 수 있고, 이전 작업이 빨리 끝난다면 다음 작업은 다음 배포 때 배포합니다.
> 이 원리로, 한 배포동안 몇 개의 작업이 동시에 배포될 수 있는지를 스택 원리로 정답 배열을 만들어 반환했습니다.

- [x] <b>가장 긴 짝수 연속한 부분 수열 (large)</b>
> 투 포인터로 풀이했습니다.

> (잡설) 1. 제가 코드랑 주석 쓰긴 했는데 뭔 소린지 모르겠네요. 다음엔 이해하기 쉽게 쓰는 연습도 해야할 것 같습니다.
> 읽는 분들은 여기에 적어놓은 설명과, 코드와 주석을 온몸으로 느끼시면 이해하기 쉬울 것 같습니다. (???)
> 2. 파일 올릴 때 indent 를 잘못 설정했더니 깃허브가 그 설정을 그대로 가지고 가서 수정하기가 어렵네요. 다음부턴 유의하겠습니다.

> 문제에서 얻을 수 있는 중요한 아이디어는, 짝수들을 건너뛰고, **연속된 홀수 수열들을 지울 때 홀수를 최대 K개만큼 제거하면, 제거한 홀수 부분과 이웃하는 연속한 짝수 부분들을 서로 이어서 길게 만들 수 있다는 점**입니다.
> 이를 위해, (1) 연속된 홀수 부분이 몇 개 있는지, (2) 그 안에 홀수 개수가 각각 몇 개 있는지, (3) 그 부분을 지우면 양옆의 짝수 부분을 이어서 어느 정도 길이의 짝수 부분 수열을 만들 수 있는지에 대한 정보가 필요합니다.
 
> 먼저, 주어진 수열을 짝수 부분 개수 / 홀수 부분 개수 / 짝 ... 짝 / 홀 / 짝 으로 가공해서, **홀수 부분마다 홀수가 몇 개 있는지**와 **홀수 부분을 지웠을 때 양옆에 있는 짝수 부분의 길이를 파악할 수 있도록 처리**했습니다.
> 맨 처음과 맨 마지막에 홀수 부분이 있다면 생략으로 처리했습니다. -> 그 부분은 지우면 비효율적입니다. 각각 맨 끝에서 두 번째 홀수 부분을 지우면 맨 끝에서 첫 번째 홀수 부분을 지우는 것보다 짝수 부분 하나를 더 얻을 수 있습니다.

> 그리고, 현재 수열에서 아무것도 지우지 않았을 때, 짝수 부분 중 최대 길이를 구했습니다. -> 홀수 부분들이 전부 K개보다 많은 홀수를 가지고 있다면, 아무것도 지우지 못하기 때문에, 아무것도 지우지 않았을 때의 결과도 알아놓아야 합니다.

> 투 포인터를 사용해 홀수를 최대 K번 지웠을 때 얻을 수 있는 최대 길이 짝수 수열을 구했습니다. **현재 지우려고 하는 홀수 부분들의 홀수 개수가 K보다 많다면, 포인터를 당겨서 지우고자 하는 홀수 부분을 줄이고, K보다 적다면 더 지울 수 있으므로, 포인터를 밀어서 지우고자 하는 홀수 부분을 늘렸습니다.**