### PR TITLE
[37주차 / 정준상] 문제풀이

### DIFF
--- a/정준상/BOJ/2025/02/1학년.java
+++ b/정준상/BOJ/2025/02/1학년.java
@@ -8,7 +8,7 @@ import java.util.*;
  * Memory           :   14.372 MB
  * Used algorithm   :   Dynamic programming
  */
-public class Main {
+class Main {
 
     private static final BufferedReader br = new BufferedReader(
             new InputStreamReader(System.in)

--- a/정준상/BOJ/2025/02/도시 분할 계획.java
+++ b/정준상/BOJ/2025/02/도시 분할 계획.java
@@ -9,7 +9,7 @@ import java.util.stream.*;
  * Memory           :   315.068 MB
  * Used algorithm   :   Minimum spanning tree (Kruskal)
  */
-public class Main {
+class Main {
 
     private static final BufferedReader br = new BufferedReader(
             new InputStreamReader(System.in)

--- a/정준상/BOJ/2025/02/파티.java
+++ b/정준상/BOJ/2025/02/파티.java
@@ -8,7 +8,7 @@ import java.util.*;
  * Memory           :   23.532 MB
  * Used algorithm   :   Shortest path (Dijkstra)
  */
-public class Main {
+class Main {
 
     private static final BufferedReader br = new BufferedReader(
             new InputStreamReader(System.in)

--- a/정준상/BOJ/2025/03/1로 만들기 2.java
+++ b/정준상/BOJ/2025/03/1로 만들기 2.java
@@ -1,0 +1,69 @@
+import java.io.*;
+import java.util.*;
+
+/**
+ * Author           :   정준상 (jbw9964)
+ * Date             :   2025-03-04
+ * Runtime          :   112 ms
+ * Memory           :   22.056 MB
+ * Used algorithm   :   BFS
+ */
+class Main {
+
+    private static final BufferedReader br = new BufferedReader(
+            new InputStreamReader(System.in)
+    );
+
+
+    public static void main(String[] args) throws IOException {
+        int N = Integer.parseInt(br.readLine());
+
+        int[] table = new int[N + 1];
+        Queue<Integer> q = new ArrayDeque<>(N);
+        q.add(N);
+
+        while (!q.isEmpty() && table[1] == 0)    {
+
+            int curr = q.poll();
+
+            int target;
+            if (curr % 3 == 0)  {
+                target = curr / 3;
+
+                if (table[target] == 0)    {
+                    table[target] = curr;
+                    q.add(target);
+                }
+            }
+
+            if (curr % 2 == 0)  {
+                target = curr / 2;
+                if (table[target] == 0)    {
+                    table[target] = curr;
+                    q.add(target);
+                }
+            }
+
+            target = curr - 1;
+            if (target >= 0 && table[target] == 0)    {
+                table[target] = curr;
+                q.add(target);
+            }
+        }
+
+        Deque<Integer> ans = new ArrayDeque<>();
+        ans.add(1);
+
+        int tmp = 1;
+        while (tmp != N)    {
+            ans.add(table[tmp]);
+            tmp = table[tmp];
+        }
+
+        System.out.println(ans.size() - 1);
+        while (!ans.isEmpty()) {
+            System.out.print(ans.pollLast() + " ");
+        }
+        System.out.println();
+    }
+}

--- a/정준상/BOJ/2025/03/칵테일.java
+++ b/정준상/BOJ/2025/03/칵테일.java
@@ -1,0 +1,123 @@
+import java.io.*;
+import java.util.*;
+import java.util.stream.*;
+
+/**
+ * Author           :   정준상 (jbw9964)
+ * Date             :   2025-03-04
+ * Runtime          :   132 ms
+ * Memory           :   16.452 MB
+ * Used algorithm   :   Graph, Union find, LCM & GCD
+ */
+class Main {
+
+    private static final BufferedReader br = new BufferedReader(
+            new InputStreamReader(System.in)
+    );
+
+    private static int N;
+    private static int[] parents;
+    private static long[] values;
+
+    public static void main(String[] args) throws IOException {
+
+        N = Integer.parseInt(br.readLine());
+
+        parents = IntStream.range(0, N).toArray();
+        values = new long[N];
+
+        for (int i = 0; i < N - 1; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+
+            // : a / b = p / q
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+            long p = Integer.parseInt(st.nextToken());
+            long q = Integer.parseInt(st.nextToken());
+
+            // gcd 안 나눠도 풀리지만 혹시 모를 overflow 방지
+            long gcd = gcd(p, q);
+            p /= gcd;
+            q /= gcd;
+
+            // 새로운 node 2 개 생성 --> 비율 맞추려고 고민 필요 X
+            if (values[a] == values[b] && values[a] == 0) {
+                values[a] = p;
+                values[b] = q;
+            }
+
+            // 새로운 node 1 개 생성 
+            // --> (존재하지 않는 node 값) & (존재하는 node 값) 비율 맞춰주면서 node 생성
+            else if (values[a] == 0) {
+                values[a] = p * values[b];
+                multiplyGivenToGroup(b, q);     // 결국 values[b] 는 q * values[b] 되서 비율 맞춰짐
+            }
+
+            else if (values[b] == 0) {
+                values[b] = q * values[a];
+                multiplyGivenToGroup(a, p);
+            }
+
+            // 이미 존재하는 node 들에 대해 비율 맞춰줘야 됨
+            else {
+                long lcm = lcm(values[a], values[b]);
+                long mulA = lcm / values[a];
+                long mulB = lcm / values[b];
+
+                // 일단 values[a], values[b] 같은 값 (lcm) 으로 맞춰줌
+                // a, b 의 sub-node 간 비율 자동으로 맞춰짐
+                multiplyGivenToGroup(a, mulA);
+                multiplyGivenToGroup(b, mulB);
+
+                // 주어진 비율로 다시 맞춰줌
+                multiplyGivenToGroup(a, p);
+                multiplyGivenToGroup(b, q);
+            }
+
+            int p1 = findParent(a);
+            int p2 = findParent(b);
+            parents[Math.max(p1, p2)] = Math.min(p1, p2);
+        }
+
+        // 나눠질 수 있는 걸로 최대한 나눠줌
+        // gcd(a, b, c) = gcd(gcd(a, b), c) 임
+        long gcd = Arrays.stream(values).reduce(values[0], Main::gcd);
+        for (long val : values) {
+            System.out.print(val / gcd + " ");
+        }
+        System.out.println();
+    }
+
+    // indexInGroup 와 같은 parent 를 가진 node 들 값을 *= mul
+    private static void multiplyGivenToGroup(int indexInGroup, long mul) {
+        if (mul > 1) {
+            int parent = findParent(indexInGroup);
+            IntStream.range(0, N)
+                    .filter(i -> findParent(i) == parent)
+                    .forEach(i -> values[i] *= mul);
+        }
+    }
+
+    private static int findParent(int i) {
+        return parents[i] = i == parents[i] ?
+                parents[i] : findParent(parents[i]);
+    }
+
+    private static long lcm(long a, long b)    {
+        long gcd = gcd(a, b);
+        return (a / gcd) * (b / gcd) * gcd;
+    }
+
+    private static long gcd(long a, long b) {
+        long max = Math.max(a, b);
+        long min = Math.min(a, b);
+
+        long mod;
+        while ((mod = max % min) != 0)  {
+            max = min;
+            min = mod;
+        }
+
+        return min;
+    }
+}

--- a/정준상/Programmers/2025/03/지게차와 크레인.java
+++ b/정준상/Programmers/2025/03/지게차와 크레인.java
@@ -1,0 +1,191 @@
+import java.util.*;
+import java.util.function.*;
+import java.util.stream.*;
+
+/**
+ * Author           :   정준상 (jbw9964)
+ * Date             :   2025-03-03
+ * Runtime          :   73.14 ms
+ * Memory           :   108 MB
+ * Used algorithm   :   BFS, Implementation
+ */
+class Solution {
+
+    private int R, C;
+    private static final int[] dr = {-1, 1, 0, 0}, dc = {0, 0, 1, -1};
+
+    private boolean inRange(int r, int c) {
+        return r >= 0 && r < R && c >= 0 && c < C;
+    }
+
+    private char[][] table;
+    private static final char OUTER = '/';
+    private static final char EMPTY = ' ';
+    private static List<Cord> edgeCords;
+
+    private void init(String[] storage) {
+        R = storage.length;
+        C = storage[0].length();
+
+        table = new char[R][];
+        for (int i = 0; i < R; i++) {
+            table[i] = storage[i].toCharArray();
+        }
+
+        // 편의를 위해 외곽 좌표들 저장
+        edgeCords = new ArrayList<>(2 * R + 2 * C - 4);
+        edgeCords.addAll(
+                IntStream.range(0, R * C)
+                        .filter(cnt -> {
+                            int nR = cnt / C, nC = cnt % C;
+                            return nR == 0 || nR == R - 1 || nC == 0 || nC == C - 1;
+                        })
+                        .mapToObj(cnt -> new Cord(cnt / C, cnt % C))
+                        .collect(Collectors.toList())
+        );
+    }
+
+    public int solution(String[] storage, String[] requests) {
+        init(storage);
+
+        int answer = R * C;
+        for (String request : requests) {
+
+            // 없앨 수 있는 좌표들 return
+            List<Cord> removals = getRemovalCords(request);
+
+            answer -= removals.size();
+
+            // 없앤 좌표들 EMPTY 로 채우기
+            fillCordsEmpty(removals);
+
+            // OUTER 로 채울 수 있는 거 채우기
+            updateOuterBlocks();
+        }
+
+        return answer;
+    }
+
+    private List<Cord> getRemovalCords(String request) {
+
+        List<Cord> removals = new ArrayList<>();
+
+        final char target = request.charAt(0);
+        BiPredicate<Integer, Integer> filter = getFilterOnRequest(request, target);
+
+        for (int i = 0; i < R; i++) {
+            for (int j = 0; j < C; j++) {
+                if (target == table[i][j] && filter.test(i, j)) {
+                    removals.add(new Cord(i, j));
+                }
+            }
+        }
+
+        return removals;
+    }
+
+    private BiPredicate<Integer, Integer> getFilterOnRequest(String request, char target) {
+        // 뭐든지 true
+        BiPredicate<Integer, Integer> pass = (r, c) -> true;
+
+        // 외곽 좌표이거나 OUTTER 와 인접해 있으면 true
+        BiPredicate<Integer, Integer> outerRegion = (r, c) -> {
+            for (int i = 0; i < dr.length; i++) {
+                int adjR = r + dr[i];
+                int adjC = c + dc[i];
+
+                if (!inRange(adjR, adjC) || table[adjR][adjC] == OUTER) {
+                    return true;
+                }
+            }
+            return false;
+        };
+
+        return request.length() >= 2 ? pass : outerRegion;
+    }
+
+    private void fillCordsEmpty(List<Cord> cords) {
+        for (Cord c : cords) {
+            table[c.r][c.c] = EMPTY;
+        }
+    }
+
+    private void updateOuterBlocks() {
+
+        List<Cord> newOuterBlocks = new ArrayList<>();
+        boolean[][] visited = new boolean[R][C];
+
+        // 외곽 좌표들로 부터 BFS 탐색
+        for (Cord edge : edgeCords) {
+            int r = edge.r, c = edge.c;
+
+            if (visited[r][c] || (table[r][c] != OUTER && table[r][c] != EMPTY)) {
+                continue;
+            }
+
+            // BFS 로 OUTTER 채울 좌표 추가
+            newOuterBlocks.addAll(getOuterBlocksWithBFS(r, c, visited));
+        }
+
+        // OUTTER 채우기
+        for (Cord c : newOuterBlocks) {
+            table[c.r][c.c] = OUTER;
+        }
+    }
+
+    private List<Cord> getOuterBlocksWithBFS(int initR, int initC, boolean[][] visited) {
+        List<Cord> outerBlocks = new ArrayList<>();
+
+        visited[initR][initC] = true;
+
+        Queue<Cord> queue = new LinkedList<>();
+        queue.add(new Cord(initR, initC));
+
+        while (!queue.isEmpty()) {
+
+            Cord c = queue.poll();
+            outerBlocks.add(c);
+
+            for (int i = 0; i < dr.length; i++) {
+                int adjR = c.r + dr[i];
+                int adjC = c.c + dc[i];
+
+                if (!inRange(adjR, adjC) || (table[adjR][adjC] != OUTER
+                        && table[adjR][adjC] != EMPTY) || visited[adjR][adjC]) {
+                    continue;
+                }
+
+                visited[adjR][adjC] = true;
+                queue.add(new Cord(adjR, adjC));
+            }
+        }
+
+        return outerBlocks;
+    }
+
+    @SuppressWarnings("unused")
+    private void showTable() {
+        for (char[] row : table) {
+            System.out.println(Arrays.toString(row));
+        }
+        System.out.println();
+    }
+}
+
+class Cord {
+
+    final int r, c;
+
+    public Cord(int r, int c) {
+        this.r = r;
+        this.c = c;
+    }
+
+    @Override
+    public String toString() {
+        return "Cord{" +
+                "r=" + r +
+                ", c=" + c +
+                '}';
+    }
+}


### PR DESCRIPTION
## :sparkles: Week35 정준상 문제풀이

- [X] **[LV2 지게차와 크레인](https://school.programmers.co.kr/learn/courses/30/lessons/388353)**

> BFS 를 활용해 구현하였습니다.
> 문제 조건처럼 `request.length() == 1` 일 때는 외곽에 존재하는 화물만, `2` 일때는 모든 화물을 제거하였습니다.
> 화물 제거 후, `OUTTER (외곽지역)` 로 채울 수 있는 곳을 탐색해 채워가며 풀이하였습니다.

---

- [x] **[G2 칵테일](https://www.acmicpc.net/problem/1033)**

> 매우 어려웠던 문제라 해답을 검색해 `그래프 유형 문제` 임을 알게 되었습니다.
> 풀이의 핵심은 `각 재료간 그룹` 을 형성해, `그룹 내 모든 원소 값` 들에게 `*= (필요한 비율)` 을 하는 과정이었습니다.
> 간단히 도식화하면 다음과 같습니다.
> 
> ```
> (문제 입력)
> 3
> 0 1 2 1
> 1 2 3 5
> ```
> ```
> ## [노드번호](노드 내부 값)
> 처리하는 입력 : 0 1 2 1
>
>   0(2) --- 1(1)                ## 새로운 node 0, 1 생성
>
> 처리하는 입력 : 1 2 3 5
>
>   0(2 * 3 = 6) --- 1(1 * 3 = 3) --- 2(1 * 5 = 5)    ## 0 -- 1 그룹에 *= 3 진행, 새로운 node 2 생성
> ```
>
> 입력 `1 2 3 5` 처리 시, `1 번 node` 는 `0 -- 1` 그룹을 형성해 있고 `1 번 node 의 값` 이 `3` 으로 변경되어야 하므로, 
> `0(2 * 3 = 6)`, `1(1 * 3 = 3)` 처럼 `0 -- 1` 그룹을 update 하는 방식이 풀이의 핵심이었습니다. 
> `(2 번 node 는 (1 의 이전 값 = 1) * (비율 = 5) 하여 2(1 * 5 = 5))`
> 
> 문제를 보고 그래프 유형일 줄을 생각도 못했는데 어렵지만 좋은 문제였던 것 같습니다.

---

- [X] **[G5 1로 만들기 2](https://www.acmicpc.net/problem/12852)**

> BFS 를 이용해 풀이하였습니다.
> 값 `N` 으로부터 `N / 3`, `N / 2`, `N - 1` 의 경우를 생성하며 값이 `1` 일 경우 탐색을 멈추도록 풀이하였습니다.
> 또한 탐색하며 `table[...]` 배열에 `파생된 이전 수` 를 기록하였고, 이를 통해 문제 정답을 도출하였습니다.

---

|                |       지게차와 크레인   |  칵테일  |     1로 만들기 2      |
|:--------------:|:---------------------:|:-----------:|:-------------:|
|    **Runtime**     |        73.14 ms        |  132 ms  |   112 ms    |
|     **Memory**     |        108 MB        |   16.452 MB    |    22.056 MB     |
| **Used algorithm** |  BFS, Implementation   | Graph, Union find, LCM & GCD | BFS |

